### PR TITLE
Fix/docs tabs titles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ drivectl
 *.log
 .gemini/
 
+recaps/

--- a/cmd/docs.go
+++ b/cmd/docs.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/ghchinoy/drivectl/internal/drive"
 	"github.com/spf13/cobra"
@@ -44,9 +45,16 @@ var docsTabsCmd = &cobra.Command{
 		if len(tabs) == 0 {
 			fmt.Println("No tabs found.")
 		} else {
-			for _, tab := range tabs {
-				fmt.Println(tab)
+			var printTabs func(tabs []*drive.TabInfo, level int)
+			printTabs = func(tabs []*drive.TabInfo, level int) {
+				for _, tab := range tabs {
+					fmt.Printf("%s%s (%s)\n", strings.Repeat("\t", level), tab.Title, tab.TabID)
+					if len(tab.Children) > 0 {
+						printTabs(tab.Children, level+1)
+					}
+				}
 			}
+			printTabs(tabs, 0)
 		}
 		return nil
 	},

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -25,7 +25,7 @@ import (
 var (
 	outputFile string
 	format     string
-	tabIndex   int
+	tabId      string
 )
 
 var getCmd = &cobra.Command{
@@ -34,12 +34,12 @@ var getCmd = &cobra.Command{
 	Long: `Downloads a file from Google Drive.
 For standard files (PDFs, images, etc.), it downloads the raw content.
 For Google Docs, it can export the entire document to various formats (txt, md, pdf, etc.) using the --format flag.
-It can also extract the plain text content of a single tab from a Google Doc using the --tab-index flag.`,
+It can also extract the plain text content of a single tab from a Google Doc using the --tab-id flag.`,
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		fileId := args[0]
 
-		content, err := drive.GetFile(driveSvc, docsSvc, fileId, format, tabIndex)
+		content, err := drive.GetFile(driveSvc, docsSvc, fileId, format, tabId)
 		if err != nil {
 			return err
 		}
@@ -47,9 +47,9 @@ It can also extract the plain text content of a single tab from a Google Doc usi
 		if outputFile != "" {
 			err := os.WriteFile(outputFile, content, 0644)
 			if err != nil {
-				return fmt.Errorf("failed to write to output file %s: %%w", outputFile, err)
+				return fmt.Errorf("failed to write to output file %s: %w", outputFile, err)
 			}
-			fmt.Printf("Successfully saved file to %%s\n", outputFile)
+			fmt.Printf("Successfully saved file to %s\n", outputFile)
 		} else {
 			// For binary formats like pdf, docx, etc., printing to console is not useful.
 			// We will just print a success message instead.
@@ -68,5 +68,5 @@ func init() {
 	rootCmd.AddCommand(getCmd)
 	getCmd.Flags().StringVarP(&outputFile, "output", "o", "", "Path to save the output file")
 	getCmd.Flags().StringVar(&format, "format", "", "Export format for Google Docs (e.g., pdf, docx, html, txt, md)")
-	getCmd.Flags().IntVar(&tabIndex, "tab-index", -1, "Index of the tab to get content from")
+	getCmd.Flags().StringVar(&tabId, "tab-id", "", "ID of the tab to get content from")
 }

--- a/internal/drive/drive.go
+++ b/internal/drive/drive.go
@@ -136,8 +136,10 @@ func GetTabs(docsSvc *docs.Service, documentId string) ([]string, error) {
 	}
 
 	var tabs []string
-	for i := range doc.Tabs {
-		tabs = append(tabs, fmt.Sprintf("Tab %d", i))
+	for _, t := range doc.Tabs {
+		if t.TabProperties != nil {
+			tabs = append(tabs, t.TabProperties.Title)
+		}
 	}
 	return tabs, nil
 }


### PR DESCRIPTION
fixes #9 

feat: Enhance docs commands with tab hierarchy and ID support

This commit significantly improves the `docs` commands:

- The `docs tabs` command now displays the full nested hierarchy of tabs with their titles and stable Tab IDs.
- The `get` command now uses a `--tab-id` flag instead of `--tab-index` to retrieve tab content, making it more robust and less prone to breaking when the document structure changes.
- The MCP server has been updated to reflect these changes, ensuring consistent behavior between the CLI and the MCP tools